### PR TITLE
refactor: revert text in pending tx ui

### DIFF
--- a/frontend/src/components/PendingAnimation.tsx
+++ b/frontend/src/components/PendingAnimation.tsx
@@ -93,7 +93,7 @@ const PendingAnimation: React.FC<PendingAnimationProps> = ({ approvalHash }) => 
       <div className="border-2 border-yellow-500 bg-black p-4 w-full max-w-sm overflow-hidden">
         <div className="flex items-center justify-between mb-2">
           <span className="text-yellow-500 text-xs arcade-text">
-            {approvalHash ? 'SIGNING INTENT TRANSACTION...' : 'APPROVING USDC...'}
+            {approvalHash ? 'RUNNIN TRANSFER...' : 'APPROVING USDC...'}
           </span>
           <span className="text-yellow-500 text-xs arcade-text blink">PLEASE WAIT</span>
         </div>


### PR DESCRIPTION
When the pending animation appear, the intent has already been signed.

Reverting to the old text: "running transfer"