### PR TITLE
fix(backend): settlement creation check

### DIFF
--- a/api/db/interface.go
+++ b/api/db/interface.go
@@ -3,9 +3,15 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"time"
 
 	"github.com/speedrun-hq/speedrun/api/models"
+)
+
+// Common database errors
+var (
+	ErrNotFound = errors.New("not found")
 )
 
 // Database interface defines the methods that a database implementation must provide

--- a/api/db/postgres.go
+++ b/api/db/postgres.go
@@ -128,8 +128,8 @@ func (p *PostgresDB) GetIntent(ctx context.Context, id string) (*models.Intent, 
 		&intent.CreatedAt,
 		&intent.UpdatedAt,
 	)
-	if err == sql.ErrNoRows {
-		return nil, fmt.Errorf("intent not found: %s", id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to get intent: %v", err)
@@ -194,7 +194,7 @@ func (p *PostgresDB) UpdateIntentStatus(ctx context.Context, id string, status m
 	}
 
 	if rowsAffected == 0 {
-		return fmt.Errorf("intent not found: %s", id)
+		return ErrNotFound
 	}
 
 	return nil
@@ -218,8 +218,8 @@ func (p *PostgresDB) GetFulfillment(ctx context.Context, id string) (*models.Ful
 		&fulfillment.CreatedAt,
 		&fulfillment.UpdatedAt,
 	)
-	if err == sql.ErrNoRows {
-		return nil, fmt.Errorf("fulfillment not found: %s", id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to get fulfillment: %v", err)
@@ -354,7 +354,7 @@ func (p *PostgresDB) GetSettlement(ctx context.Context, id string) (*models.Sett
 		&settlement.UpdatedAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, fmt.Errorf("settlement not found: %s", id)
+		return nil, ErrNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to get settlement: %v", err)

--- a/api/db/postgres.go
+++ b/api/db/postgres.go
@@ -415,6 +415,7 @@ func (p *PostgresDB) CreateSettlement(ctx context.Context, settlement *models.Se
 		INSERT INTO settlements (
 			id, asset, amount, receiver, fulfilled, fulfiller, actual_amount, paid_tip, tx_hash, is_call, call_data, created_at, updated_at
 		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+		ON CONFLICT (id) DO NOTHING
 	`
 
 	// Ensure timestamps are set

--- a/api/db/postgres.go
+++ b/api/db/postgres.go
@@ -332,7 +332,7 @@ func (p *PostgresDB) GetTotalFulfilledAmount(ctx context.Context, intentID strin
 // GetSettlement retrieves a settlement by ID
 func (p *PostgresDB) GetSettlement(ctx context.Context, id string) (*models.Settlement, error) {
 	query := `
-		SELECT id, asset, amount, receiver, fulfilled, fulfiller, actual_amount, paid_tip, tx_hash, created_at, updated_at
+		SELECT id, asset, amount, receiver, fulfilled, fulfiller, actual_amount, paid_tip, tx_hash, is_call, call_data, created_at, updated_at
 		FROM settlements
 		WHERE id = $1
 	`
@@ -348,6 +348,8 @@ func (p *PostgresDB) GetSettlement(ctx context.Context, id string) (*models.Sett
 		&settlement.ActualAmount,
 		&settlement.PaidTip,
 		&settlement.TxHash,
+		&settlement.IsCall,
+		&settlement.CallData,
 		&settlement.CreatedAt,
 		&settlement.UpdatedAt,
 	)
@@ -363,7 +365,7 @@ func (p *PostgresDB) GetSettlement(ctx context.Context, id string) (*models.Sett
 // ListSettlements retrieves all settlements
 func (p *PostgresDB) ListSettlements(ctx context.Context) ([]*models.Settlement, error) {
 	query := `
-		SELECT id, asset, amount, receiver, fulfilled, fulfiller, actual_amount, paid_tip, tx_hash, created_at, updated_at
+		SELECT id, asset, amount, receiver, fulfilled, fulfiller, actual_amount, paid_tip, tx_hash, is_call, call_data, created_at, updated_at
 		FROM settlements
 		ORDER BY created_at DESC
 	`
@@ -391,6 +393,8 @@ func (p *PostgresDB) ListSettlements(ctx context.Context) ([]*models.Settlement,
 			&s.ActualAmount,
 			&s.PaidTip,
 			&s.TxHash,
+			&s.IsCall,
+			&s.CallData,
 			&s.CreatedAt,
 			&s.UpdatedAt,
 		)
@@ -409,8 +413,8 @@ func (p *PostgresDB) ListSettlements(ctx context.Context) ([]*models.Settlement,
 func (p *PostgresDB) CreateSettlement(ctx context.Context, settlement *models.Settlement) error {
 	query := `
 		INSERT INTO settlements (
-			id, asset, amount, receiver, fulfilled, fulfiller, actual_amount, paid_tip, tx_hash, created_at, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			id, asset, amount, receiver, fulfilled, fulfiller, actual_amount, paid_tip, tx_hash, is_call, call_data, created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 	`
 
 	// Ensure timestamps are set
@@ -433,6 +437,8 @@ func (p *PostgresDB) CreateSettlement(ctx context.Context, settlement *models.Se
 		settlement.ActualAmount,
 		settlement.PaidTip,
 		settlement.TxHash,
+		settlement.IsCall,
+		settlement.CallData,
 		settlement.CreatedAt,
 		settlement.UpdatedAt,
 	)
@@ -1069,7 +1075,7 @@ func (p *PostgresDB) ListSettlementsPaginated(
 
 	// Get paginated results
 	query := `
-		SELECT id, asset, amount, receiver, fulfilled, fulfiller, actual_amount, paid_tip, tx_hash, created_at, updated_at
+		SELECT id, asset, amount, receiver, fulfilled, fulfiller, actual_amount, paid_tip, tx_hash, is_call, call_data, created_at, updated_at
 		FROM settlements
 		ORDER BY created_at DESC
 		LIMIT $1 OFFSET $2
@@ -1098,6 +1104,8 @@ func (p *PostgresDB) ListSettlementsPaginated(
 			&s.ActualAmount,
 			&s.PaidTip,
 			&s.TxHash,
+			&s.IsCall,
+			&s.CallData,
 			&s.CreatedAt,
 			&s.UpdatedAt,
 		)
@@ -1194,6 +1202,8 @@ func (p *PostgresDB) ListSettlementsPaginatedOptimized(
 			&s.ActualAmount,
 			&s.PaidTip,
 			&s.TxHash,
+			&s.IsCall,
+			&s.CallData,
 			&s.CreatedAt,
 			&s.UpdatedAt,
 			&totalCount,
@@ -1315,14 +1325,14 @@ func (p *PostgresDB) PrepareStatements(ctx context.Context) error {
 	p.listSettlementsStmt, err = p.db.PrepareContext(ctx, `
 		WITH data AS (
 			SELECT id, asset, amount, receiver, fulfilled, fulfiller, actual_amount, 
-				   paid_tip, tx_hash, created_at, updated_at,
+				   paid_tip, tx_hash, is_call, call_data, created_at, updated_at,
 				   COUNT(*) OVER() AS total_count
 			FROM settlements
 			ORDER BY created_at DESC
 			LIMIT $1 OFFSET $2
 		)
 		SELECT id, asset, amount, receiver, fulfilled, fulfiller, actual_amount,
-			   paid_tip, tx_hash, created_at, updated_at,
+			   paid_tip, tx_hash, is_call, call_data, created_at, updated_at,
 			   total_count
 		FROM data
 	`)

--- a/api/db/postgres_test.go
+++ b/api/db/postgres_test.go
@@ -172,6 +172,8 @@ func TestCreateSettlement(t *testing.T) {
 		ActualAmount: "900000000000000000", // 0.9 ETH
 		PaidTip:      "100000000000000000", // 0.1 ETH
 		TxHash:       "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+		IsCall:       false,
+		CallData:     "",
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}
@@ -188,6 +190,8 @@ func TestCreateSettlement(t *testing.T) {
 			settlement.ActualAmount,
 			settlement.PaidTip,
 			settlement.TxHash,
+			settlement.IsCall,
+			settlement.CallData,
 			settlement.CreatedAt,
 			settlement.UpdatedAt,
 		).
@@ -222,6 +226,8 @@ func TestGetSettlement(t *testing.T) {
 		ActualAmount: "900000000000000000", // 0.9 ETH
 		PaidTip:      "100000000000000000", // 0.1 ETH
 		TxHash:       "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+		IsCall:       false,
+		CallData:     "",
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}
@@ -229,12 +235,13 @@ func TestGetSettlement(t *testing.T) {
 	// Setup the expected rows
 	rows := sqlmock.NewRows([]string{
 		"id", "asset", "amount", "receiver", "fulfilled", "fulfiller",
-		"actual_amount", "paid_tip", "tx_hash", "created_at", "updated_at",
+		"actual_amount", "paid_tip", "tx_hash", "is_call", "call_data", "created_at", "updated_at",
 	}).
 		AddRow(
 			expectedSettlement.ID, expectedSettlement.Asset, expectedSettlement.Amount,
 			expectedSettlement.Receiver, expectedSettlement.Fulfilled, expectedSettlement.Fulfiller,
 			expectedSettlement.ActualAmount, expectedSettlement.PaidTip, expectedSettlement.TxHash,
+			expectedSettlement.IsCall, expectedSettlement.CallData,
 			expectedSettlement.CreatedAt, expectedSettlement.UpdatedAt,
 		)
 

--- a/api/services/catchup.go
+++ b/api/services/catchup.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math/big"
@@ -1228,7 +1229,7 @@ func (s *EventCatchupService) catchUpOnIntentEvents(
 						existingIntent, err := s.db.GetIntent(getIntentCtx, intentID)
 						cancel()
 
-						if err != nil && !strings.Contains(err.Error(), "not found") {
+						if err != nil && !errors.Is(err, db.ErrNotFound) {
 							return fmt.Errorf("failed to check for existing intent: %v", err)
 						}
 
@@ -1435,7 +1436,7 @@ func (s *EventCatchupService) catchUpOnFulfillmentEvents(
 						cancel()
 
 						if err != nil {
-							if strings.Contains(err.Error(), "not found") {
+							if errors.Is(err, db.ErrNotFound) {
 								s.logger.Debug().
 									Str("operation", opName).
 									Str(logging.FieldIntent, intentID).
@@ -1643,7 +1644,7 @@ func (s *EventCatchupService) catchUpOnSettlementEvents(
 						cancel()
 
 						if err != nil {
-							if strings.Contains(err.Error(), "not found") {
+							if errors.Is(err, db.ErrNotFound) {
 								s.logger.Debug().
 									Str("operation", opName).
 									Str(logging.FieldIntent, intentID).

--- a/api/services/fulfillment.go
+++ b/api/services/fulfillment.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -473,10 +474,10 @@ func (s *FulfillmentService) CreateFulfillment(ctx context.Context, intentID, tx
 	// Validate intent exists
 	intent, err := s.db.GetIntent(ctx, intentID)
 	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return fmt.Errorf("intent not found: %s", intentID)
+		}
 		return fmt.Errorf("failed to get intent: %v", err)
-	}
-	if intent == nil {
-		return fmt.Errorf("intent not found: %s", intentID)
 	}
 
 	// For API-created fulfillments, try to get the block timestamp from the transaction
@@ -607,10 +608,10 @@ func (s *FulfillmentService) CreateCallFulfillment(
 	// Validate intent exists
 	intent, err := s.db.GetIntent(ctx, intentID)
 	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return fmt.Errorf("intent not found: %s", intentID)
+		}
 		return fmt.Errorf("failed to get intent: %v", err)
-	}
-	if intent == nil {
-		return fmt.Errorf("intent not found: %s", intentID)
 	}
 
 	// Verify this is a call intent

--- a/api/services/intent.go
+++ b/api/services/intent.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -826,7 +827,7 @@ func (s *IntentService) processLog(ctx context.Context, vLog types.Log) error {
 	existingIntent, err := s.db.GetIntent(dbCtx, intent.ID)
 	dbCancel()
 
-	if err != nil && !strings.Contains(err.Error(), "not found") {
+	if err != nil && !errors.Is(err, db.ErrNotFound) {
 		return fmt.Errorf("failed to check for existing intent: %v", err)
 	}
 
@@ -1129,7 +1130,7 @@ func (s *IntentService) GetIntent(ctx context.Context, id string) (*models.Inten
 	intent, err := s.db.GetIntent(ctx, id)
 	if err != nil {
 		// Check if the error is "not found"
-		if strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, db.ErrNotFound) {
 			// Try to check on-chain via RPC if this intent exists
 			s.logger.Error().
 				Str(logging.FieldIntent, id).

--- a/api/services/settlement.go
+++ b/api/services/settlement.go
@@ -445,13 +445,10 @@ func (s *SettlementService) CreateSettlement(ctx context.Context, settlement *mo
 	// Check if settlement already exists
 	existingSettlement, err := s.db.GetSettlement(ctx, settlement.ID)
 	if err != nil {
-		// If error is not "not found", return it
 		if !strings.Contains(err.Error(), "settlement not found") {
-			return fmt.Errorf("failed to check existing settlement: %v", err)
+			return fmt.Errorf("failed to check for existing settlement: %v", err)
 		}
-		// Settlement doesn't exist, proceed with creation
 	} else if existingSettlement != nil {
-		// Settlement already exists, log and return without error
 		s.logger.Debug().
 			Str("settlement_id", settlement.ID).
 			Msg("Settlement already exists, skipping creation")


### PR DESCRIPTION
- Check if settlement exists  already in db before attempting to create
-  Return  isCall and callData from db for settlement operations
- Switch to using ErrNotFound

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settlement records now support call-based settlements with an indicator and optional details, reflected in creation, retrieval, and listing responses.
* **Bug Fixes**
  * Prevents duplicate settlements from being created, improving data integrity and consistency across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->