### PR TITLE
feat: add failed intent status in the api

### DIFF
--- a/api/models/types.go
+++ b/api/models/types.go
@@ -54,6 +54,9 @@ const (
 
 	// IntentStatusSettled indicates the intent has been settled on the target chain
 	IntentStatusSettled IntentStatus = "settled"
+
+	// IntentStatusFailed indicates the cross-chain transaction failed
+	IntentStatusFailed IntentStatus = "failed"
 )
 
 // ToResponse converts an Intent to an IntentResponse

--- a/api/services/settlement.go
+++ b/api/services/settlement.go
@@ -461,7 +461,7 @@ func (s *SettlementService) CreateSettlement(ctx context.Context, settlement *mo
 		return fmt.Errorf("failed to create settlement: %v", err)
 	}
 
-	// Update intent status
+	// Settlement finalizes the intent irrespective of fulfillment outcome
 	if err := s.db.UpdateIntentStatus(ctx, settlement.ID, models.IntentStatusSettled); err != nil {
 		return fmt.Errorf("failed to update intent status: %v", err)
 	}

--- a/api/services/settlement.go
+++ b/api/services/settlement.go
@@ -461,8 +461,12 @@ func (s *SettlementService) CreateSettlement(ctx context.Context, settlement *mo
 		return fmt.Errorf("failed to create settlement: %v", err)
 	}
 
-	// Settlement finalizes the intent irrespective of fulfillment outcome
-	if err := s.db.UpdateIntentStatus(ctx, settlement.ID, models.IntentStatusSettled); err != nil {
+	// Mark failed if settlement indicates unsuccessful fulfillment; otherwise settled
+	status := models.IntentStatusSettled
+	if !settlement.Fulfilled {
+		status = models.IntentStatusFailed
+	}
+	if err := s.db.UpdateIntentStatus(ctx, settlement.ID, status); err != nil {
 		return fmt.Errorf("failed to update intent status: %v", err)
 	}
 


### PR DESCRIPTION
add failed intent status in the api for when an intent is not fulfilled when settlement is recorded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a “Failed” status for intents to clearly indicate unsuccessful cross-chain transactions.
* **Bug Fixes**
  * Corrected status updates so unfulfilled settlements are marked as “Failed” instead of incorrectly showing as “Settled,” improving accuracy and transparency of transaction states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->